### PR TITLE
feat: add "activationRules" parameters to the plugin

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,8 @@ export const shareExtensionEntitlementsFileName = `${shareExtensionName}.entitle
 export const shareExtensionStoryBoardFileName = 'MainInterface.storyboard';
 export const shareExtensionViewControllerFileName = 'ShareViewController.swift';
 
+export type Parameters = { activationRules?: { [key: string]: number | boolean | string}  }
+
 export const getAppGroups = (identifier: string) => [`group.${identifier}`];
 
 export const getShareExtensionBundledIdentifier = (appIdentifier: string) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   withPlugins,
 } from "@expo/config-plugins";
 
+import { Parameters } from "./constants";
 import { withAppEntitlements } from "./withAppEntitlements";
 import { withShareExtensionConfig } from "./withShareExtensionConfig";
 import { withShareExtensionXcodeTarget } from "./withShareExtensionXcodeTarget";
@@ -13,12 +14,12 @@ let pkg: { name: string; version?: string } = {
   version: "UNVERSIONED",
 };
 
-const withShareMenu: ConfigPlugin = createRunOncePlugin(
-  (config) => {
+const withShareMenu: ConfigPlugin<Parameters> = createRunOncePlugin(
+  (config, params) => {
     return withPlugins(config, [
       withAppEntitlements,
       withShareExtensionConfig,
-      withShareExtensionXcodeTarget,
+      () => withShareExtensionXcodeTarget(config, params),
     ]);
   },
   pkg.name,

--- a/src/withShareExtensionXcodeTarget.ts
+++ b/src/withShareExtensionXcodeTarget.ts
@@ -1,6 +1,6 @@
 import { ConfigPlugin, withXcodeProject } from '@expo/config-plugins';
 
-import { getShareExtensionBundledIdentifier, shareExtensionName } from './constants';
+import { Parameters, getShareExtensionBundledIdentifier, shareExtensionName } from './constants';
 import {
   getShareExtensionEntitlementsFilePath,
   getShareExtensionInfoFilePath,
@@ -9,7 +9,7 @@ import {
   writeShareExtensionFiles,
 } from './writeShareExtensionFiles';
 
-export const withShareExtensionXcodeTarget: ConfigPlugin = (config) => {
+export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (config, parameters) => {
   return withXcodeProject(config, async (config) => {
     const extensionName = shareExtensionName;
     const platformProjectRoot = config.modRequest.platformProjectRoot;
@@ -24,7 +24,7 @@ export const withShareExtensionXcodeTarget: ConfigPlugin = (config) => {
     const viewControllerFilePath = getShareExtensionViewControllerPath(platformProjectRoot);
     const storyboardFilePath = getShareExtensionStoryboardFilePath(platformProjectRoot);
 
-    await writeShareExtensionFiles(platformProjectRoot, scheme, appIdentifier);
+    await writeShareExtensionFiles(platformProjectRoot, scheme, appIdentifier, parameters);
 
     const pbxProject = config.modResults;
 

--- a/src/writeShareExtensionFiles.ts
+++ b/src/writeShareExtensionFiles.ts
@@ -9,15 +9,17 @@ import {
   shareExtensionInfoFileName,
   shareExtensionStoryBoardFileName,
   shareExtensionViewControllerFileName,
+  Parameters,
 } from "./constants";
 
 export async function writeShareExtensionFiles(
   platformProjectRoot: string,
   scheme: string,
-  appIdentifier: string
+  appIdentifier: string,
+  parameters: Parameters
 ) {
   const infoPlistFilePath = getShareExtensionInfoFilePath(platformProjectRoot);
-  const infoPlistContent = getShareExtensionInfoContent();
+  const infoPlistContent = getShareExtensionInfoContent(parameters.activationRules);
   await fs.promises.mkdir(path.dirname(infoPlistFilePath), { recursive: true });
   await fs.promises.writeFile(infoPlistFilePath, infoPlistContent);
 
@@ -34,7 +36,7 @@ export async function writeShareExtensionFiles(
 
   const viewControllerFilePath =
     getShareExtensionViewControllerPath(platformProjectRoot);
-  const viewControllerContent = getShareExtensionViewControllerContent(scheme);
+  const viewControllerContent = getShareExtensionViewControllerContent(scheme, appIdentifier);
   await fs.promises.writeFile(viewControllerFilePath, viewControllerContent);
 }
 
@@ -68,7 +70,7 @@ export function getShareExtensionInfoFilePath(platformProjectRoot: string) {
   );
 }
 
-export function getShareExtensionInfoContent() {
+export function getShareExtensionInfoContent(activationRules: Parameters["activationRules"]) {
   return plist.build({
     CFBundleName: "$(PRODUCT_NAME)",
     CFBundleDisplayName: "Share Extension",
@@ -79,7 +81,7 @@ export function getShareExtensionInfoContent() {
     CFBundlePackageType: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)",
     NSExtension: {
       NSExtensionAttributes: {
-        NSExtensionActivationRule: {
+        NSExtensionActivationRule: activationRules || {
           NSExtensionActivationSupportsWebURLWithMaxCount: 1,
           NSExtensionActivationSupportsWebPageWithMaxCount: 1,
         },
@@ -140,8 +142,8 @@ export function getShareExtensionViewControllerPath(
   );
 }
 
-export function getShareExtensionViewControllerContent(scheme: string) {
-  console.debug("************ scheme", scheme);
+export function getShareExtensionViewControllerContent(scheme: string, appIdentifier: string) {
+  console.debug("************ scheme", scheme, "appIdentifier", appIdentifier);
 
   return `import MobileCoreServices
   import Social


### PR DESCRIPTION

In order to prepare plugin for the next version with "Support receiving more content types", this PR add support to customize "plist" file `NSExtensionActivationRule` content from app.json

Example

```json
  "plugins": [
     [
       "expo-config-plugin-ios-share-extension", 
       {
          "activationRules": {
             "NSExtensionActivationSupportsText": true
          }
       }
     ]
  ],
```
